### PR TITLE
Set hidden agora flag to cache iframe

### DIFF
--- a/c_src/membrane_agora_plugin/sink.cpp
+++ b/c_src/membrane_agora_plugin/sink.cpp
@@ -36,6 +36,10 @@ UNIFEX_TERM create(UnifexEnv *env, char *appId, char *token, char *channelId,
   ccfg.clientRoleType = agora::rtc::CLIENT_ROLE_BROADCASTER;
   state->connection = state->service->createRtcConnection(ccfg);
 
+  // Cache initial i-frame at agora
+  auto s = state->connection->getAgoraParameter();
+  s->setBool("che.video.has_intra_request", false);
+
   // connecting
   auto connObserver = std::make_shared<ConnectionObserver>();
   state->connection->registerObserver(connObserver.get());


### PR DESCRIPTION
The agora team has suggested this change to help with the black screen we see as the agora session loads, they suggested:

```
Step 1. Set the private parameter at Linux SDK side before connecting to Agora server. This parameter will cache i frame at Agora backend server so that receiver doesn’t have to send intra request to get a i frame.
auto s = connection->getAgoraParameter();
ret = s->setBool("che.video.has_intra_request",false);

Step 2. If step 1 doesn’t help, continue step 2 by applying AgoraRTC.setParameter(“ENABLE_INSTANT_VIDEO”, true) at Web Audience side. Note. This parameter applies for Agora web sdk 4.19.0+ version. The latest version is 4.19.1.
```