### PR TITLE
Add ability to specify Agora's SDK build URL

### DIFF
--- a/bundlex.exs
+++ b/bundlex.exs
@@ -33,7 +33,7 @@ defmodule Membrane.Agora.BundlexProject do
     {_output, result} = System.shell("./install.sh #{url}")
     if result != 0 do
       IO.warn("""
-      Couldn't fetch SDK from the following URL: #{url}
+      Couldn't get SDK with the following URL: #{url}
       """)
     end
 

--- a/bundlex.exs
+++ b/bundlex.exs
@@ -14,10 +14,25 @@ defmodule Membrane.Agora.BundlexProject do
 
   def project do
     case get_target() do
-      %{os: "linux"} ->
-        System.shell("./install.sh")
+      %{os: "linux", architecture: :x86_64} ->
+        System.shell("./install.sh https://download.agora.io/sdk/release/Agora-RTC-x86_64-linux-gnu-v3.8.202.20-20220627_152601-214165.tgz")
+
       other_target ->
-        IO.warn("Agora's Server Gateway SDK is unavailable for this target: #{inspect(other_target)}")
+        url = System.get_env("AGORA_SDK_URL")
+        if url do
+          {_output, result} = System.shell("./install.sh #{url}")
+          if result != 0 do
+            IO.warn("""
+            Couldn't fetch SDK from the following URL: #{url}
+            """)
+          end
+        else
+          IO.warn("""
+          Agora's Server Gateway SDK build location unknown for target #{inspect(other_target)}.
+          You can pass the URL as AGORA_SDK_URL environmental variable.
+          """)
+        end
+
     end
 
     [

--- a/bundlex.exs
+++ b/bundlex.exs
@@ -13,26 +13,28 @@ defmodule Membrane.Agora.BundlexProject do
   end
 
   def project do
-    case get_target() do
+    url = case get_target() do
       %{os: "linux", architecture: :x86_64} ->
-        System.shell("./install.sh https://download.agora.io/sdk/release/Agora-RTC-x86_64-linux-gnu-v3.8.202.20-20220627_152601-214165.tgz")
+        "https://download.agora.io/sdk/release/Agora-RTC-x86_64-linux-gnu-v3.8.202.20-20220627_152601-214165.tgz"
 
       other_target ->
         url = System.get_env("AGORA_SDK_URL")
         if url do
-          {_output, result} = System.shell("./install.sh #{url}")
-          if result != 0 do
-            IO.warn("""
-            Couldn't fetch SDK from the following URL: #{url}
-            """)
-          end
+          url
         else
           IO.warn("""
           Agora's Server Gateway SDK build location unknown for target #{inspect(other_target)}.
           You can pass the URL as AGORA_SDK_URL environmental variable.
           """)
+          ""
         end
+    end
 
+    {_output, result} = System.shell("./install.sh #{url}")
+    if result != 0 do
+      IO.warn("""
+      Couldn't fetch SDK from the following URL: #{url}
+      """)
     end
 
     [

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,13 @@
 #! /bin/bash
 
 if ! test -d ./agora_sdk; then
-    wget -qO- $1 | tar xvz 
+    if [[ $1 == http* ]]; then
+        wget -qO- $1 | tar xvz 
+    else
+        tar xvf $1
+    fi
+
     mv agora_rtc_sdk/agora_sdk .
-    rm -r agora_rtc_sdk
+    rm -r agora_rtc_sdk 
+    
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,7 @@
 #! /bin/bash
 
 if ! test -d ./agora_sdk; then
-    wget https://download.agora.io/sdk/release/Agora-RTC-x86_64-linux-gnu-v3.8.202.20-20220627_152601-214165.tgz
-    tar xvf Agora-RTC-x86_64-linux-gnu-v3.8.202.20-20220627_152601-214165.tgz
-    rm  Agora-RTC-x86_64-linux-gnu-v3.8.202.20-20220627_152601-214165.tgz
+    wget -qO- $1 | tar xvz 
     mv agora_rtc_sdk/agora_sdk .
     rm -r agora_rtc_sdk
 fi


### PR DESCRIPTION
This PR:
* adds an ability to specify URL (path to file or link) to a place where Agora SDK is available. To do so, the user needs to specify `AGORA_SDK_URL` environmental variable