### PR TITLE
Fix a bug with conditional compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ docker run -it membraneframeworklabs/docker_membrane
 
 To use that plugin in your project, add the following line to your deps in `mix.exs`:
 ```
-	{:membrane_agora_plugin, "~> 0.2.2"}
+	{:membrane_agora_plugin, "~> 0.2.3"}
 ```
 
 Run `mix deps.get`.

--- a/lib/agora/agora_sink_native.ex
+++ b/lib/agora/agora_sink_native.ex
@@ -1,7 +1,7 @@
 defmodule Membrane.Agora.Sink.Native do
   @moduledoc false
 
-  if Bundlex.get_target() == %{os: "linux", architecture: "x86_64"} do
+  if match?(%{os: "linux", architecture: "x86_64"}, Bundlex.get_target()) do
     use Unifex.Loader
   end
 end

--- a/lib/agora/agora_source_native.ex
+++ b/lib/agora/agora_source_native.ex
@@ -1,7 +1,7 @@
 defmodule Membrane.Agora.Source.Native do
   @moduledoc false
 
-  if Bundlex.get_target() == %{os: "linux", architecture: "x86_64"} do
+  if match?(%{os: "linux", architecture: "x86_64"}, Bundlex.get_target()) do
     use Unifex.Loader
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.Agora.Mixfile do
   use Mix.Project
 
-  @version "0.2.2"
+  @version "0.2.3"
   @github_url "https://github.com/membraneframework/membrane_agora_plugin"
 
   def project do


### PR DESCRIPTION
This PR:
* fixes a bug by using `match?` instead of `==` to compare results of `Bundlex.get_target()`